### PR TITLE
support multiple query param pairs

### DIFF
--- a/src/main/shadow/experiments/grove/http_fx.cljs
+++ b/src/main/shadow/experiments/grove/http_fx.cljs
@@ -62,7 +62,9 @@
   ;; there are too many different url encoding schemes to cover all
   (reduce-kv
     (fn [s key val]
-      (str (js/encodeURIComponent (name key)) "=" (js/encodeURIComponent (str val))))
+      (str s
+           (when-not (str/blank? s) "&")
+           (js/encodeURIComponent (name key)) "=" (js/encodeURIComponent (str val))))
     ""
     m))
 


### PR DESCRIPTION
Example to illustrate the problem being fixed:
```clojure
;; only one pair is encoded
(http/query-params->str {} {:age 42 :name "bob"})

;; used to make request urls
(http/as-uri {} ["foo" {:age 42 :name "bob"}]) ;; "foo?name=bob"
 ;; name is dropped here (as it should)
(http/as-uri {} ["foo" {:age 42} {:name "bob"}])
;; currently, only? way to have multiple query params
(http/as-uri {} ["foo" "?age=42" {:name "bob"}]) ;; "foo/?age=42&name=bob"
```